### PR TITLE
Add a unit testing framework for direct translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,25 @@
 # apidoc-swagger-generator
 
 A Lambda function that translates from the Apidoc service.json to a JSON document that adheres to Swagger Spec 2.0
+
+## Testing
+
+There are some unit tests that rely on service.json from from existing APIs hosted in Apidoc. These can be refreshed
+by running
+
+  ```
+  > bin/refresh-specs.sh
+  ```
+
+These should be refreshed whenever the service.json format changes, or the APIs themselves change in a way that we
+would like to capture in testing here. The changes should be checked in, to document how the tests have changed over
+time. In order to run the script, you need to have [jq](https://stedolan.github.io/jq/download/) installed locally.
+
+For the .json files that contain the Swagger output, it is a manual process to:
+
+  1. Capture the output
+  2. Properly [lint](https://jsonlint.com) the output
+  3. Import it into Swagger
+  4. Verify that the resultant Swagger definition properly reflects the original service.json
+
+Due to #4, this process isn't automated.

--- a/bin/refresh-specs.sh
+++ b/bin/refresh-specs.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+testApis=( "bryzek swagger-petstore" "bryzek apidoc-example-union-types")
+
+for orgAndService in "${testApis[@]}"
+do
+  apidoc download $orgAndService latest service | jq '.' > test/resources/service/${orgAndService/ /-}.json
+done

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
   },
   "devDependencies": {
+    "aws-lambda-mock-context": "^1.1.0",
     "mocha": "^2.4.5"
   }
 }

--- a/test/app/apidoc-swagger-generator.js
+++ b/test/app/apidoc-swagger-generator.js
@@ -1,0 +1,38 @@
+const assert = require('assert'),
+      context = require('aws-lambda-mock-context'),
+      fs = require('fs'),
+      generator = require('../../app/apidoc-swagger-generator');
+
+describe('apidoc-swagger-generator', function() {
+  describe('example files', function() {
+    const serviceSourceDir = 'test/resources/service';
+    const swaggerSourceDir = 'test/resources/swagger';
+    fs.readdirSync(serviceSourceDir).forEach(function(path) {
+      it('should correctly parse ' + path, function() {
+        serviceDoc = JSON.parse(fs.readFileSync(serviceSourceDir + '/' + path).toString());
+        translateServiceJson(serviceDoc, function(swaggerDoc) {
+          swaggerExpectedDoc = JSON.parse(fs.readFileSync(swaggerSourceDir + '/' + path).toString());
+          assert.deepEqual(swaggerDoc, expectedSwaggerDoc);
+        });
+      });
+    });
+  })
+});
+
+function translateServiceJson(serviceJson, callback) {
+  var ctx = newContext();
+  generator.handler({body: JSON.stringify({"service": serviceJson})}, ctx);
+  return ctx.Promise
+  .then(function(results) {
+    assert.equal(results.statusCode, 200);
+    callback(JSON.parse(JSON.parse(results.body).source));
+  });
+}
+
+function newContext() {
+  return context({
+    region: "us-east-1",
+    account: "1234567890",
+    functionName: "test"
+  });
+}

--- a/test/resources/service/bryzek-apidoc-example-union-types.json
+++ b/test/resources/service/bryzek-apidoc-example-union-types.json
@@ -1,0 +1,290 @@
+{
+  "headers": [],
+  "version": "0.3.46",
+  "organization": {
+    "key": "bryzek"
+  },
+  "imports": [],
+  "enums": [
+    {
+      "plural": "bars",
+      "description": null,
+      "deprecation": null,
+      "attributes": [],
+      "values": [
+        {
+          "description": null,
+          "deprecation": null,
+          "attributes": [],
+          "name": "b"
+        }
+      ],
+      "name": "bar"
+    },
+    {
+      "plural": "foos",
+      "description": null,
+      "deprecation": null,
+      "attributes": [],
+      "values": [
+        {
+          "description": null,
+          "deprecation": null,
+          "attributes": [],
+          "name": "a"
+        }
+      ],
+      "name": "foo"
+    }
+  ],
+  "resources": [
+    {
+      "plural": "users",
+      "type": "user",
+      "path": "/users",
+      "description": null,
+      "deprecation": null,
+      "attributes": [],
+      "operations": [
+        {
+          "responses": [
+            {
+              "type": "[user]",
+              "description": null,
+              "deprecation": null,
+              "code": {
+                "integer": {
+                  "value": 200
+                }
+              }
+            }
+          ],
+          "path": "/users",
+          "body": null,
+          "method": "GET",
+          "description": null,
+          "deprecation": null,
+          "attributes": [],
+          "parameters": []
+        },
+        {
+          "responses": [
+            {
+              "type": "user",
+              "description": null,
+              "deprecation": null,
+              "code": {
+                "integer": {
+                  "value": 200
+                }
+              }
+            },
+            {
+              "type": "unit",
+              "description": null,
+              "deprecation": null,
+              "code": {
+                "integer": {
+                  "value": 404
+                }
+              }
+            }
+          ],
+          "path": "/users/:guid",
+          "body": null,
+          "method": "GET",
+          "description": null,
+          "deprecation": null,
+          "attributes": [],
+          "parameters": [
+            {
+              "type": "uuid",
+              "minimum": null,
+              "default": null,
+              "maximum": null,
+              "location": "Path",
+              "example": null,
+              "description": null,
+              "deprecation": null,
+              "name": "guid",
+              "required": true
+            }
+          ]
+        },
+        {
+          "responses": [
+            {
+              "type": "user",
+              "description": null,
+              "deprecation": null,
+              "code": {
+                "integer": {
+                  "value": 201
+                }
+              }
+            }
+          ],
+          "path": "/users",
+          "body": {
+            "type": "user",
+            "description": null,
+            "deprecation": null,
+            "attributes": []
+          },
+          "method": "POST",
+          "description": null,
+          "deprecation": null,
+          "attributes": [],
+          "parameters": []
+        }
+      ]
+    }
+  ],
+  "application": {
+    "key": "apidoc-example-union-types"
+  },
+  "unions": [
+    {
+      "types": [
+        {
+          "type": "foo",
+          "description": null,
+          "deprecation": null,
+          "attributes": []
+        },
+        {
+          "type": "bar",
+          "description": null,
+          "deprecation": null,
+          "attributes": []
+        }
+      ],
+      "plural": "foobars",
+      "description": null,
+      "deprecation": null,
+      "attributes": [],
+      "name": "foobar",
+      "discriminator": null
+    },
+    {
+      "types": [
+        {
+          "type": "registered_user",
+          "description": null,
+          "deprecation": null,
+          "attributes": []
+        },
+        {
+          "type": "guest_user",
+          "description": null,
+          "deprecation": null,
+          "attributes": []
+        },
+        {
+          "type": "uuid",
+          "description": null,
+          "deprecation": null,
+          "attributes": []
+        }
+      ],
+      "plural": "users",
+      "description": null,
+      "deprecation": null,
+      "attributes": [],
+      "name": "user",
+      "discriminator": null
+    }
+  ],
+  "description": null,
+  "apidoc": {
+    "version": "0.11.54"
+  },
+  "models": [
+    {
+      "plural": "guest_users",
+      "fields": [
+        {
+          "type": "uuid",
+          "minimum": null,
+          "default": null,
+          "maximum": null,
+          "example": null,
+          "description": "Internal unique identifier for this user.",
+          "deprecation": null,
+          "attributes": [],
+          "name": "guid",
+          "required": true
+        },
+        {
+          "type": "string",
+          "minimum": null,
+          "default": null,
+          "maximum": null,
+          "example": null,
+          "description": null,
+          "deprecation": null,
+          "attributes": [],
+          "name": "email",
+          "required": true
+        }
+      ],
+      "description": null,
+      "deprecation": null,
+      "attributes": [],
+      "name": "guest_user"
+    },
+    {
+      "plural": "registered_users",
+      "fields": [
+        {
+          "type": "uuid",
+          "minimum": null,
+          "default": null,
+          "maximum": null,
+          "example": null,
+          "description": "Internal unique identifier for this user.",
+          "deprecation": null,
+          "attributes": [],
+          "name": "guid",
+          "required": true
+        },
+        {
+          "type": "string",
+          "minimum": null,
+          "default": null,
+          "maximum": null,
+          "example": null,
+          "description": null,
+          "deprecation": null,
+          "attributes": [],
+          "name": "email",
+          "required": true
+        },
+        {
+          "type": "foobar",
+          "minimum": null,
+          "default": null,
+          "maximum": null,
+          "example": null,
+          "description": null,
+          "deprecation": null,
+          "attributes": [],
+          "name": "preference",
+          "required": true
+        }
+      ],
+      "description": null,
+      "deprecation": null,
+      "attributes": [],
+      "name": "registered_user"
+    }
+  ],
+  "base_url": null,
+  "attributes": [],
+  "name": "apidoc-example-union-types",
+  "info": {
+    "license": null,
+    "contact": null
+  },
+  "namespace": "com.bryzek.apidoc.example.union.types.v0"
+}

--- a/test/resources/service/bryzek-swagger-petstore.json
+++ b/test/resources/service/bryzek-swagger-petstore.json
@@ -1,0 +1,410 @@
+{
+  "headers": [],
+  "version": "0.0.1-dev",
+  "organization": {
+    "key": "bryzek"
+  },
+  "imports": [],
+  "enums": [],
+  "resources": [
+    {
+      "plural": "Pets",
+      "type": "Pet",
+      "path": null,
+      "description": null,
+      "deprecation": null,
+      "attributes": [],
+      "operations": [
+        {
+          "responses": [
+            {
+              "type": "[Pet]",
+              "description": "pet response",
+              "deprecation": null,
+              "code": {
+                "integer": {
+                  "value": 200
+                }
+              }
+            },
+            {
+              "type": "ErrorModel",
+              "description": "unexpected error",
+              "deprecation": null,
+              "code": {
+                "response_code_option": "Default"
+              }
+            }
+          ],
+          "path": "/pets",
+          "body": null,
+          "method": "GET",
+          "description": "Returns all pets from the system that the user has access to",
+          "deprecation": null,
+          "attributes": [],
+          "parameters": [
+            {
+              "type": "string",
+              "minimum": null,
+              "default": null,
+              "maximum": null,
+              "location": "Query",
+              "example": null,
+              "description": "tags to filter by\n\nCollection Format: $f",
+              "deprecation": null,
+              "name": "tags",
+              "required": false
+            },
+            {
+              "type": "integer",
+              "minimum": null,
+              "default": null,
+              "maximum": null,
+              "location": "Query",
+              "example": null,
+              "description": "maximum number of results to return",
+              "deprecation": null,
+              "name": "limit",
+              "required": false
+            }
+          ]
+        },
+        {
+          "responses": [
+            {
+              "type": "Pet",
+              "description": "pet response",
+              "deprecation": null,
+              "code": {
+                "integer": {
+                  "value": 200
+                }
+              }
+            },
+            {
+              "type": "ErrorModel",
+              "description": "unexpected error",
+              "deprecation": null,
+              "code": {
+                "response_code_option": "Default"
+              }
+            }
+          ],
+          "path": "/pets",
+          "body": {
+            "type": "NewPet",
+            "description": "Pet to add to the store",
+            "deprecation": null,
+            "attributes": []
+          },
+          "method": "POST",
+          "description": "Creates a new pet in the store.  Duplicates are allowed",
+          "deprecation": null,
+          "attributes": [],
+          "parameters": []
+        },
+        {
+          "responses": [
+            {
+              "type": "[Pet]",
+              "description": "pet response",
+              "deprecation": null,
+              "code": {
+                "integer": {
+                  "value": 200
+                }
+              }
+            },
+            {
+              "type": "ErrorModel",
+              "description": "unexpected error",
+              "deprecation": null,
+              "code": {
+                "response_code_option": "Default"
+              }
+            }
+          ],
+          "path": "/pets",
+          "body": null,
+          "method": "GET",
+          "description": "Returns all pets from the system that the user has access to",
+          "deprecation": null,
+          "attributes": [],
+          "parameters": [
+            {
+              "type": "string",
+              "minimum": null,
+              "default": null,
+              "maximum": null,
+              "location": "Query",
+              "example": null,
+              "description": "tags to filter by\n\nCollection Format: $f",
+              "deprecation": null,
+              "name": "tags",
+              "required": false
+            },
+            {
+              "type": "integer",
+              "minimum": null,
+              "default": null,
+              "maximum": null,
+              "location": "Query",
+              "example": null,
+              "description": "maximum number of results to return",
+              "deprecation": null,
+              "name": "limit",
+              "required": false
+            }
+          ]
+        },
+        {
+          "responses": [
+            {
+              "type": "Pet",
+              "description": "pet response",
+              "deprecation": null,
+              "code": {
+                "integer": {
+                  "value": 200
+                }
+              }
+            },
+            {
+              "type": "ErrorModel",
+              "description": "unexpected error",
+              "deprecation": null,
+              "code": {
+                "response_code_option": "Default"
+              }
+            }
+          ],
+          "path": "/pets",
+          "body": {
+            "type": "NewPet",
+            "description": "Pet to add to the store",
+            "deprecation": null,
+            "attributes": []
+          },
+          "method": "POST",
+          "description": "Creates a new pet in the store.  Duplicates are allowed",
+          "deprecation": null,
+          "attributes": [],
+          "parameters": []
+        },
+        {
+          "responses": [
+            {
+              "type": "Pet",
+              "description": "pet response",
+              "deprecation": null,
+              "code": {
+                "integer": {
+                  "value": 200
+                }
+              }
+            },
+            {
+              "type": "ErrorModel",
+              "description": "unexpected error",
+              "deprecation": null,
+              "code": {
+                "response_code_option": "Default"
+              }
+            }
+          ],
+          "path": "/pets/:id",
+          "body": null,
+          "method": "GET",
+          "description": "Returns a user based on a single ID, if the user does not have access to the pet",
+          "deprecation": null,
+          "attributes": [],
+          "parameters": [
+            {
+              "type": "long",
+              "minimum": null,
+              "default": null,
+              "maximum": null,
+              "location": "Path",
+              "example": null,
+              "description": "ID of pet to fetch",
+              "deprecation": null,
+              "name": "id",
+              "required": true
+            }
+          ]
+        },
+        {
+          "responses": [
+            {
+              "type": "unit",
+              "description": "pet deleted",
+              "deprecation": null,
+              "code": {
+                "integer": {
+                  "value": 204
+                }
+              }
+            },
+            {
+              "type": "ErrorModel",
+              "description": "unexpected error",
+              "deprecation": null,
+              "code": {
+                "response_code_option": "Default"
+              }
+            }
+          ],
+          "path": "/pets/:id",
+          "body": null,
+          "method": "DELETE",
+          "description": "deletes a single pet based on the ID supplied",
+          "deprecation": null,
+          "attributes": [],
+          "parameters": [
+            {
+              "type": "long",
+              "minimum": null,
+              "default": null,
+              "maximum": null,
+              "location": "Path",
+              "example": null,
+              "description": "ID of pet to delete",
+              "deprecation": null,
+              "name": "id",
+              "required": true
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "application": {
+    "key": "swagger-petstore"
+  },
+  "unions": [],
+  "description": "A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification",
+  "apidoc": {
+    "version": "0.11.54"
+  },
+  "models": [
+    {
+      "plural": "NewPets",
+      "fields": [
+        {
+          "type": "string",
+          "minimum": null,
+          "default": null,
+          "maximum": null,
+          "example": null,
+          "description": null,
+          "deprecation": null,
+          "attributes": [],
+          "name": "name",
+          "required": true
+        },
+        {
+          "type": "string",
+          "minimum": null,
+          "default": null,
+          "maximum": null,
+          "example": null,
+          "description": null,
+          "deprecation": null,
+          "attributes": [],
+          "name": "tag",
+          "required": false
+        }
+      ],
+      "description": null,
+      "deprecation": null,
+      "attributes": [],
+      "name": "NewPet"
+    },
+    {
+      "plural": "Pets",
+      "fields": [
+        {
+          "type": "string",
+          "minimum": null,
+          "default": null,
+          "maximum": null,
+          "example": null,
+          "description": null,
+          "deprecation": null,
+          "attributes": [],
+          "name": "name",
+          "required": true
+        },
+        {
+          "type": "string",
+          "minimum": null,
+          "default": null,
+          "maximum": null,
+          "example": null,
+          "description": null,
+          "deprecation": null,
+          "attributes": [],
+          "name": "tag",
+          "required": false
+        },
+        {
+          "type": "long",
+          "minimum": null,
+          "default": null,
+          "maximum": null,
+          "example": null,
+          "description": null,
+          "deprecation": null,
+          "attributes": [],
+          "name": "id",
+          "required": true
+        }
+      ],
+      "description": null,
+      "deprecation": null,
+      "attributes": [],
+      "name": "Pet"
+    },
+    {
+      "plural": "ErrorModels",
+      "fields": [
+        {
+          "type": "integer",
+          "minimum": null,
+          "default": null,
+          "maximum": null,
+          "example": null,
+          "description": null,
+          "deprecation": null,
+          "attributes": [],
+          "name": "code",
+          "required": true
+        },
+        {
+          "type": "string",
+          "minimum": null,
+          "default": null,
+          "maximum": null,
+          "example": null,
+          "description": null,
+          "deprecation": null,
+          "attributes": [],
+          "name": "message",
+          "required": true
+        }
+      ],
+      "description": null,
+      "deprecation": null,
+      "attributes": [],
+      "name": "ErrorModel"
+    }
+  ],
+  "base_url": "http://petstore.swagger.io/api",
+  "attributes": [],
+  "name": "Swagger Petstore",
+  "info": {
+    "license": null,
+    "contact": null
+  },
+  "namespace": "com.bryzek.swagger.petstore.v0"
+}

--- a/test/resources/swagger/bryzek-apidoc-example-union-types.json
+++ b/test/resources/swagger/bryzek-apidoc-example-union-types.json
@@ -1,0 +1,142 @@
+{
+	"swagger": "2.0",
+	"info": {
+		"title": "apidoc-example-union-types",
+		"description": null,
+		"version": "0.3.46"
+	},
+	"schemes": [""],
+	"consumes": ["application/json"],
+	"produces": ["application/json"],
+	"paths": {
+		"/users": {
+			"get": {
+				"description": null,
+				"parameters": [{
+					"name": "guid",
+					"in": "path",
+					"description": null,
+					"required": true,
+					"format": "uuid",
+					"type": "string",
+					"default": null,
+					"maximum": null,
+					"minimum": null
+				}],
+				"responses": {
+					"200": {
+						"description": null,
+						"schema": {
+							"$ref": "#/definitions/user"
+						}
+					},
+					"404": {
+						"description": null,
+						"schema": {
+							"$ref": "#/definitions/unit"
+						}
+					}
+				}
+			},
+			"post": {
+				"description": null,
+				"parameters": [{
+					"name": "user",
+					"in": "body",
+					"description": null,
+					"schema": {
+						"$ref": "#/definitions/user"
+					}
+				}],
+				"responses": {
+					"201": {
+						"description": null,
+						"schema": {
+							"$ref": "#/definitions/user"
+						}
+					}
+				}
+			}
+		}
+	},
+	"definitions": {
+		"guest_user": {
+			"type": "object",
+			"description": null,
+			"title": "guest_user",
+			"required": ["guid", "email"],
+			"properties": {
+				"guid": {
+					"type": "string",
+					"format": "uuid",
+					"description": "Internal unique identifier for this user.",
+					"default": null,
+					"maximum": null,
+					"minimum": null,
+					"example": null
+				},
+				"email": {
+					"type": "string",
+					"description": null,
+					"default": null,
+					"maximum": null,
+					"minimum": null,
+					"example": null
+				}
+			}
+		},
+		"registered_user": {
+			"type": "object",
+			"description": null,
+			"title": "registered_user",
+			"required": ["guid", "email", "preference"],
+			"properties": {
+				"guid": {
+					"type": "string",
+					"format": "uuid",
+					"description": "Internal unique identifier for this user.",
+					"default": null,
+					"maximum": null,
+					"minimum": null,
+					"example": null
+				},
+				"email": {
+					"type": "string",
+					"description": null,
+					"default": null,
+					"maximum": null,
+					"minimum": null,
+					"example": null
+				},
+				"preference": {
+					"$ref": "#/definitions/foobar"
+				}
+			}
+		},
+		"foobar": {
+			"type": "object",
+			"description": null,
+			"title": "foobar",
+			"allOf": [{
+				"type": "string",
+				"enum": ["a"]
+			}, {
+				"type": "string",
+				"enum": ["b"]
+			}]
+		},
+		"user": {
+			"type": "object",
+			"description": null,
+			"title": "user",
+			"allOf": [{
+				"$ref": "#/definitions/registered_user"
+			}, {
+				"$ref": "#/definitions/guest_user"
+			}, {
+				"type": "string",
+				"format": "uuid"
+			}]
+		}
+	}
+}

--- a/test/resources/swagger/bryzek-swagger-petstore.json
+++ b/test/resources/swagger/bryzek-swagger-petstore.json
@@ -1,0 +1,182 @@
+{
+	"swagger": "2.0",
+	"info": {
+		"title": "Swagger Petstore",
+		"description": "A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification",
+		"version": "0.0.1-dev"
+	},
+	"host": "petstore.swagger.io",
+	"basePath": "/api",
+	"schemes": ["http"],
+	"consumes": ["application/json"],
+	"produces": ["application/json"],
+	"paths": {
+		"/pets": {
+			"get": {
+				"description": "Returns a user based on a single ID, if the user does not have access to the pet",
+				"parameters": [{
+					"name": "id",
+					"in": "path",
+					"description": "ID of pet to fetch",
+					"required": true,
+					"format": "int64",
+					"type": "integer",
+					"default": null,
+					"maximum": null,
+					"minimum": null
+				}],
+				"responses": {
+					"200": {
+						"description": "pet response",
+						"schema": {
+							"$ref": "#/definitions/Pet"
+						}
+					},
+					"default": {
+						"description": "unexpected error",
+						"schema": {
+							"$ref": "#/definitions/ErrorModel"
+						}
+					}
+				}
+			},
+			"post": {
+				"description": "Creates a new pet in the store.  Duplicates are allowed",
+				"parameters": [{
+					"name": "NewPet",
+					"in": "body",
+					"description": "Pet to add to the store",
+					"schema": {
+						"$ref": "#/definitions/NewPet"
+					}
+				}],
+				"responses": {
+					"200": {
+						"description": "pet response",
+						"schema": {
+							"$ref": "#/definitions/Pet"
+						}
+					},
+					"default": {
+						"description": "unexpected error",
+						"schema": {
+							"$ref": "#/definitions/ErrorModel"
+						}
+					}
+				}
+			},
+			"delete": {
+				"description": "deletes a single pet based on the ID supplied",
+				"parameters": [{
+					"name": "id",
+					"in": "path",
+					"description": "ID of pet to delete",
+					"required": true,
+					"format": "int64",
+					"type": "integer",
+					"default": null,
+					"maximum": null,
+					"minimum": null
+				}],
+				"responses": {
+					"204": {
+						"description": "pet deleted",
+						"schema": {
+							"$ref": "#/definitions/unit"
+						}
+					},
+					"default": {
+						"description": "unexpected error",
+						"schema": {
+							"$ref": "#/definitions/ErrorModel"
+						}
+					}
+				}
+			}
+		}
+	},
+	"definitions": {
+		"NewPet": {
+			"type": "object",
+			"description": null,
+			"title": "NewPet",
+			"required": ["name"],
+			"properties": {
+				"name": {
+					"type": "string",
+					"description": null,
+					"default": null,
+					"maximum": null,
+					"minimum": null,
+					"example": null
+				},
+				"tag": {
+					"type": "string",
+					"description": null,
+					"default": null,
+					"maximum": null,
+					"minimum": null,
+					"example": null
+				}
+			}
+		},
+		"Pet": {
+			"type": "object",
+			"description": null,
+			"title": "Pet",
+			"required": ["name", "id"],
+			"properties": {
+				"name": {
+					"type": "string",
+					"description": null,
+					"default": null,
+					"maximum": null,
+					"minimum": null,
+					"example": null
+				},
+				"tag": {
+					"type": "string",
+					"description": null,
+					"default": null,
+					"maximum": null,
+					"minimum": null,
+					"example": null
+				},
+				"id": {
+					"type": "integer",
+					"format": "int64",
+					"description": null,
+					"default": null,
+					"maximum": null,
+					"minimum": null,
+					"example": null
+				}
+			}
+		},
+		"ErrorModel": {
+			"type": "object",
+			"description": null,
+			"title": "ErrorModel",
+			"required": ["code", "message"],
+			"properties": {
+				"code": {
+					"type": "integer",
+					"format": "int32",
+					"description": null,
+					"default": null,
+					"maximum": null,
+					"minimum": null,
+					"example": null
+				},
+				"message": {
+					"type": "string",
+					"description": null,
+					"default": null,
+					"maximum": null,
+					"minimum": null,
+					"example": null
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
The idea is to pull existing example Apidoc definitions (though we can also
manually add service.json files to the directory too) and map those to
an expected swagger.json. If either changes, we simply edit the JSON on
either end and the test doesn't change.

Please note that the existing swagger.json examples are not valid Swagger
2.0 documents; I will follow up this commit with more commits to address
those problems.